### PR TITLE
Add structured SLF4J logging to backend

### DIFF
--- a/backend/src/main/java/com/notif/backend/controller/AdminDataController.java
+++ b/backend/src/main/java/com/notif/backend/controller/AdminDataController.java
@@ -6,6 +6,8 @@ import com.notif.backend.dto.UserEventDTO;
 import com.notif.backend.service.EventService;
 import com.notif.backend.service.UserEventService;
 import com.notif.backend.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -20,6 +22,8 @@ import java.util.List;
 @PreAuthorize("!hasRole('USER')")
 public class AdminDataController {
 
+    private static final Logger log = LoggerFactory.getLogger(AdminDataController.class);
+
     private final UserEventService userEventService;
     private final EventService eventService;
     private final UserService userService;
@@ -33,9 +37,11 @@ public class AdminDataController {
 
     @GetMapping(value = "/users")
     public ResponseEntity<List<UserDTO>> getUserData() {
+        log.info("Admin requested full user list");
         try {
             return new ResponseEntity<>(userService.getUserData(), HttpStatusCode.valueOf(200));
         } catch (Exception e) {
+            log.error("Failed to load user data for admin", e);
             return new ResponseEntity<>(HttpStatusCode.valueOf(500));
         }
     }

--- a/backend/src/main/java/com/notif/backend/controller/UserController.java
+++ b/backend/src/main/java/com/notif/backend/controller/UserController.java
@@ -5,6 +5,8 @@ import com.notif.backend.dto.UserDTO;
 import com.notif.backend.service.ICalService;
 import com.notif.backend.service.UserEventService;
 import com.notif.backend.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -22,6 +24,8 @@ import java.util.List;
 @PreAuthorize("hasRole('USER')")
 public class UserController {
 
+    private static final Logger log = LoggerFactory.getLogger(UserController.class);
+
     private final UserService userService;
     private final UserEventService userEventService;
     private final ICalService icalService;
@@ -36,8 +40,9 @@ public class UserController {
     public ResponseEntity<UserDTO> updateUserData(@RequestBody UserDTO userDto) {
         try {
             UserDTO updated = userService.updateUserData(userDto);
-            return ResponseEntity.ok(updated); //Status 200
+            return ResponseEntity.ok(updated);
         } catch (Exception e) {
+            log.error("Failed to update user", e);
             return ResponseEntity.status(500).build();
         }
     }
@@ -48,6 +53,7 @@ public class UserController {
             userService.deleteUserData(userId);
             return new ResponseEntity<>(HttpStatusCode.valueOf(200));
         } catch (Exception e) {
+            log.error("Failed to delete user id={}", userId, e);
             return new ResponseEntity<>(HttpStatusCode.valueOf(500));
         }
     }
@@ -58,6 +64,7 @@ public class UserController {
             @AuthenticationPrincipal Jwt jwt) {
         UserDTO requester = userService.getOrCreateUser(jwt);
         if (!requester.id().equals(userId)) {
+            log.warn("Access denied: user {} tried to access events of user {}", requester.id(), userId);
             return ResponseEntity.status(403).build();
         }
         return ResponseEntity.ok(userEventService.getEventsForUser(userId));
@@ -112,6 +119,7 @@ public class UserController {
             @AuthenticationPrincipal Jwt jwt) {
         UserDTO requester = userService.getOrCreateUser(jwt);
         if (!requester.id().equals(userId)) {
+            log.warn("Access denied: user {} tried to access profile of user {}", requester.id(), userId);
             return ResponseEntity.status(403).build();
         }
         return ResponseEntity.ok(userService.getUserByID(userId));
@@ -119,8 +127,8 @@ public class UserController {
 
     @GetMapping("/sync")
     public ResponseEntity<UserDTO> syncLogin(@AuthenticationPrincipal Jwt jwt) {
-        // Ruft den Service auf, der getOrCreateUser implementiert
         UserDTO user = userService.getOrCreateUser(jwt);
+        log.info("User logged in: userId={}", user.id());
         return ResponseEntity.ok(user);
     }
 

--- a/backend/src/main/java/com/notif/backend/service/EventService.java
+++ b/backend/src/main/java/com/notif/backend/service/EventService.java
@@ -6,6 +6,8 @@ import com.notif.backend.entity.Event;
 import com.notif.backend.entity.UserEvent;
 import com.notif.backend.repository.EventRepository;
 import com.notif.backend.repository.UserEventRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +15,8 @@ import java.util.List;
 
 @Service
 public class EventService {
+
+    private static final Logger log = LoggerFactory.getLogger(EventService.class);
 
     private final EventRepository eventRepository;
 
@@ -25,6 +29,7 @@ public class EventService {
 
     @Transactional
     public Event saveOrUpdateEvent(EventDTO dto) {
+        log.debug("Upserting event {}", dto.id());
         Event event = eventRepository.findById(dto.id())
                 .orElse(new Event());
 

--- a/backend/src/main/java/com/notif/backend/service/TMService.java
+++ b/backend/src/main/java/com/notif/backend/service/TMService.java
@@ -42,8 +42,8 @@ public class TMService {
     }
 
     public String getRawEvents(String keyword, String city, int size) {
+        log.debug("Fetching raw events: keyword={}, city={}, size={}", keyword, city, size);
         String url = tmQueryBuilder.buildSearchUrl(baseUrl, apiKey, keyword, city, size);
-        System.out.println("Ticketmaster URL: " + url);
         return restTemplate.getForObject(url, String.class);
     }
 
@@ -99,8 +99,10 @@ public class TMService {
             }
 
         } catch (Exception e) {
+            log.error("Failed to parse Ticketmaster response", e);
             throw new RuntimeException("Failed to parse Ticketmaster response", e);
         }
+        log.debug("Parsed {} events from Ticketmaster response", concerts.size());
         return concerts;
     }
 

--- a/backend/src/main/java/com/notif/backend/service/UserEventService.java
+++ b/backend/src/main/java/com/notif/backend/service/UserEventService.java
@@ -10,6 +10,8 @@ import com.notif.backend.repository.EventRepository;
 import com.notif.backend.repository.UserEventRepository;
 import com.notif.backend.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,8 @@ import java.util.UUID;
 
 @Service
 public class UserEventService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserEventService.class);
 
     private final UserEventRepository userEventRepository;
     private final UserRepository userRepository;
@@ -49,15 +53,18 @@ public class UserEventService {
 
     @Transactional
     public void removeEventFromUserProfile(Long userId, String eventId) {
+        log.info("Removing event {} from profile of user {}", eventId, userId);
         userEventRepository.deleteByUserAndEvent(userId, eventId);
         // Remove the event itself if no user has it saved anymore
         if (!userEventRepository.existsByEvent_Id(eventId)) {
+            log.info("Event {} has no remaining owners, deleting from DB", eventId);
             eventRepository.deleteById(eventId);
         }
     }
 
     @Transactional
     public void addEventToUserProfile(Long userId, com.notif.backend.dto.EventDTO eventDTO) {
+        log.info("Adding event {} to profile of user {}", eventDTO.id(), userId);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
 
@@ -76,6 +83,7 @@ public class UserEventService {
 
         // No duplicate entries for same user-event combination
         if (userEventRepository.existsByUser_IdAndEvent_Id(userId, event.getId())) {
+            log.debug("Event {} already saved for user {}, skipping", event.getId(), userId);
             return;
         }
 

--- a/backend/src/main/java/com/notif/backend/service/UserService.java
+++ b/backend/src/main/java/com/notif/backend/service/UserService.java
@@ -4,6 +4,8 @@ import com.notif.backend.dto.UserDTO;
 import com.notif.backend.entity.User;
 import com.notif.backend.repository.UserEventRepository;
 import com.notif.backend.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +14,8 @@ import java.util.List;
 
 @Service
 public class UserService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserService.class);
 
     private final UserRepository userRepository;
     private final UserEventRepository userEventRepository;
@@ -27,11 +31,13 @@ public class UserService {
 
     @Transactional
     public UserDTO updateUserData(UserDTO user) {
+        log.info("Updating user id={}", user.id());
         return userRepository.save(new User(user)).toDTO();
     }
 
     @Transactional
     public void deleteUserData(Long id) {
+        log.info("Deleting user id={}", id);
         userRepository.deleteById(id);
     }
 
@@ -50,7 +56,9 @@ public class UserService {
                     User newUser = new User();
                     newUser.setExternalId(externalId);
                     newUser.setUserName(username);
-                    return userRepository.save(newUser);
+                    User saved = userRepository.save(newUser);
+                    log.info("JIT provisioning: created new user externalId={}, username={}", externalId, username);
+                    return saved;
                 });
 
         return user.toDTO();

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,2 +1,8 @@
 spring.liquibase.contexts=dev
 spring.liquibase.show-summary=summary
+
+# Logging (development: verbose)
+logging.level.com.notif.backend=DEBUG
+logging.level.org.springframework.web=INFO
+logging.level.org.springframework.cache.interceptor=TRACE
+logging.pattern.console=%clr(%d{HH:mm:ss.SSS}){faint} %clr(%-5level) [%clr(%logger{0}){cyan}] - %msg%n

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -24,3 +24,6 @@ spring.security.oauth2.resourceserver.jwt.issuer-uri=http://${KC_HOST:localhost}
 # Redis
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
+
+# Logging (production: important events only)
+logging.level.com.notif.backend=INFO

--- a/frontend/src/auth/authState.js
+++ b/frontend/src/auth/authState.js
@@ -11,7 +11,15 @@ export const authState = reactive({
   userId: null,
 })
 
+let syncInProgress = null
+
 export async function syncAuthState() {
+  if (syncInProgress) return syncInProgress
+  syncInProgress = _doSync().finally(() => { syncInProgress = null })
+  return syncInProgress
+}
+
+async function _doSync() {
   authState.initialized = true
   authState.authenticated = !!keycloak.authenticated
 


### PR DESCRIPTION
Logged events (all visible in IntelliJ Run console with dev profile active):

INFO  - User login:              GET /api/user/sync
INFO  - JIT user provisioning:   first login of a new Keycloak user
INFO  - Ticketmaster API call:   keyword, city, size, date range (cache miss only)
INFO  - Event saved to profile:  userId + eventId
INFO  - Event removed:           userId + eventId
INFO  - Event deleted from DB:   when last owner removes it
INFO  - Admin user list request: GET /api/admin/users
WARN  - Unauthorized access:     user tried to read another user's events or profile
ERROR - Failed operations:       update/delete user, admin data load, Ticketmaster parse
DEBUG - Parsed event count:      number of events from Ticketmaster response (dev only)
DEBUG - Duplicate save skipped:  same user + event already exists (dev only)
TRACE - Cache hit/miss:          per search key, via Spring CacheInterceptor (dev only)

Also removed System.out.println in TMService that leaked the Ticketmaster API key. DEBUG/TRACE logs require active dev profile (application-dev.properties sets level=DEBUG).
closes #30 